### PR TITLE
[feature] Performance optimizations and benchmark

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -42,4 +43,47 @@ jobs:
         with:
           run: ./gradlew allTests --no-daemon
 
- 
+      - name: Combine benchmark reports
+        if: github.event_name == 'pull_request'
+        run: |
+          {
+            echo "## Benchmark Results"
+            echo ""
+            cat kotlin-lib/build/reports/benchmark-scan.md
+            cat kotlin-lib/build/reports/benchmark-init.md
+            cat kotlin-lib/build/reports/benchmark-consistency.md
+          } > benchmark.md
+
+      - name: Post benchmark results to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- benchmark-results -->';
+            const body = fs.readFileSync('benchmark.md', 'utf8');
+            const fullBody = marker + '\n' + body;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: fullBody,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,47 @@ HyperScanEngine(Matchers.filterIsInstance<IHyperMatcher>()).use { engine ->
 }
 ```
 
+### Fast startup with a pre-compiled HyperScan database
+Compiling regular expressions on every startup can be slow when the matcher set is large.
+You can compile once, save the database, and reload it instantly on subsequent runs.
+
+```kotlin
+import org.angryscan.common.engine.hyperscan.HyperScanEngine
+import org.angryscan.common.engine.hyperscan.IHyperMatcher
+import org.angryscan.common.extensions.Matchers
+import java.io.File
+
+val matchers = Matchers.filterIsInstance<IHyperMatcher>()
+val dbFile = File("hyperscan.db")
+
+// First run — compile and save
+HyperScanEngine(matchers).use { engine ->
+    engine.saveCompiledDatabase(dbFile)
+}
+
+// Subsequent runs — load (no compilation)
+HyperScanEngine.fromCompiledDatabase(matchers, dbFile).use { engine ->
+    engine.scan(text).forEach { match ->
+        println("${match.matcher.name}: ${match.value}")
+    }
+}
+```
+
+In-memory `ByteArray` variants are also available:
+
+```kotlin
+// Save to bytes
+val bytes: ByteArray = engine.saveCompiledDatabase()
+
+// Load from bytes
+val fast = HyperScanEngine.fromCompiledDatabase(matchers, bytes)
+```
+
+> **Compatibility note:** the saved database is tied to the exact matcher set, their order,
+> and the `requireKeywords` flag used during compilation.
+> Loading a database with a different configuration will throw `IllegalArgumentException`.
+> The binary format is also platform-specific (see Hyperscan documentation).
+
 ### Portable detection with KotlinEngine
 ```kotlin
 import org.angryscan.common.engine.kotlin.IKotlinMatcher

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 #Kotlin
 kotlin.code.style=official
 
-version=1.4.8
+version=1.5.0

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/constants/CardBins.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/constants/CardBins.kt
@@ -9,9 +9,9 @@ package org.angryscan.common.constants
  */
 expect object CardBins {
     /**
-     * A list of card BIN patterns used for card issuer identification.
-     * Each string in the list represents a BIN pattern that can be matched against
+     * A set of card BIN patterns used for card issuer identification.
+     * Each string in the set represents a BIN pattern that can be matched against
      * the beginning of a card number to identify the card issuer.
      */
-    val cardBins: List<String>
+    val cardBins: Set<String>
 }

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/engine/kotlin/KotlinEngine.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/engine/kotlin/KotlinEngine.kt
@@ -1,6 +1,7 @@
 package org.angryscan.common.engine.kotlin
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import org.angryscan.common.engine.IScanEngine
 import org.angryscan.common.engine.Match
 
@@ -9,41 +10,35 @@ class KotlinEngine(
     @Serializable override val matchers: List<IKotlinMatcher>,
     val requireKeywords: Boolean = true
 ) : IScanEngine {
-    override fun scan(text: String): List<Match> {
-        return matchers.flatMap { pattern ->
-            regexDetector(
-                text,
-                pattern
-            )
-        }
-    }
-
-    fun regexDetector(text: String, pattern: IKotlinMatcher): List<Match> {
-        val matches = pattern
-            .getJavaPatterns(requireKeywords)
-            .flatMap { str ->
-                str.toRegex(
-                    pattern.regexOptions
-                ).findAll(text)
-                    .filter { pattern.check(it.value) }
-                    .map { match ->
-                        Match(
-                            value = match.value,
-                            before = text.substring(
-                                maxOf(0, match.range.first - 10),
-                                match.range.first
-                            ),
-                            after = "$text ".substring(
-                                match.range.last + 1,
-                                minOf(match.range.last + 11, text.length)
-                            ),
-                            startPosition = match.range.first.toLong(),
-                            endPosition = match.range.last.toLong(),
-                            matcher = pattern
-                        )
-                    }
+    @Transient
+    private val compiledPatterns: List<Pair<Regex, IKotlinMatcher>> =
+        matchers.flatMap { matcher ->
+            matcher.getJavaPatterns(requireKeywords).map { pattern ->
+                pattern.toRegex(matcher.regexOptions) to matcher
             }
-        return matches.distinct()
+        }
+
+    override fun scan(text: String): List<Match> {
+        return compiledPatterns.flatMap { (regex, matcher) ->
+            regex.findAll(text)
+                .filter { matcher.check(it.value) }
+                .map { match ->
+                    Match(
+                        value = match.value,
+                        before = text.substring(
+                            maxOf(0, match.range.first - 10),
+                            match.range.first
+                        ),
+                        after = if (match.range.last + 1 < text.length)
+                            text.substring(match.range.last + 1, minOf(match.range.last + 11, text.length))
+                        else "",
+                        startPosition = match.range.first.toLong(),
+                        endPosition = match.range.last.toLong(),
+                        matcher = matcher
+                    )
+                }
+                .toList()
+        }.distinct()
     }
 
     override fun close() {}

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/APOFPODPO.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/APOFPODPO.kt
@@ -52,9 +52,12 @@ object APOFPODPO : IHyperMatcher, IKotlinMatcher {
     private val validCityCodes = setOf("APO", "FPO", "DPO")
     private val validStateCodes = setOf("AA", "AE", "AP")
 
+    private val CHECK_MILITARY_ADDRESS_REGEX =
+        Regex("""(APO|FPO|DPO)\s+(AA|AE|AP)\s+(\d{5})(?:-(\d{4}))?""", RegexOption.IGNORE_CASE)
+
     override fun check(value: String): Boolean {
         // Extract address parts
-        val match = Regex("""(APO|FPO|DPO)\s+(AA|AE|AP)\s+(\d{5})(?:-(\d{4}))?""", RegexOption.IGNORE_CASE).find(value)
+        val match = CHECK_MILITARY_ADDRESS_REGEX.find(value)
         if (match == null) return false
         
         val cityCode = match.groupValues[1].uppercase()

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/AddressUS.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/AddressUS.kt
@@ -47,9 +47,12 @@ object AddressUS : IHyperMatcher, IKotlinMatcher {
         "UT", "VA", "VT", "WA", "WI", "WV", "WY"
     )
 
+    private val STATE_ZIP_REGEX = Regex("""\s+([a-zA-Z]{2})\s+(\d{5})""", RegexOption.IGNORE_CASE)
+    private val LEADING_HOUSE_NUMBER_REGEX = Regex("""^\d{1,8}\s*""")
+
     override fun check(value: String): Boolean {
         // Check that state code is valid (support any case)
-        val stateMatch = Regex("""\s+([a-zA-Z]{2})\s+(\d{5})""", RegexOption.IGNORE_CASE).find(value)
+        val stateMatch = STATE_ZIP_REGEX.find(value)
         if (stateMatch == null) return false
         
         val stateCode = stateMatch.groupValues[1].uppercase()
@@ -65,7 +68,7 @@ object AddressUS : IHyperMatcher, IKotlinMatcher {
         // Extract part before state code
         val beforeState = stateMatch.range.first
         val addressWithNumber = value.substring(0, beforeState)
-        val addressPart = addressWithNumber.replace(Regex("""^\d{1,8}\s*"""), "").trim()
+        val addressPart = addressWithNumber.replace(LEADING_HOUSE_NUMBER_REGEX, "").trim()
         if (addressPart.length < 7) return false
         
         return true

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/CardNumber.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/CardNumber.kt
@@ -56,8 +56,12 @@ class CardNumber(val checkCardBins: Boolean = true) : IHyperMatcher, IKotlinMatc
         ExpressionOption.MULTILINE
     )
 
+    companion object {
+        private val NON_DIGIT_REGEX = Regex("[^0-9]")
+    }
+
     override fun check(value: String): Boolean {
-        val cleanCard = value.replace("[^0-9]".toRegex(), "")
+        val cleanCard = value.replace(NON_DIGIT_REGEX, "")
         return cleanCard != "0000000000000000"
                 && (!checkCardBins || isBinValid(cleanCard))
                 && isCardValid(cleanCard)

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/CryptoSeedPhrase.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/CryptoSeedPhrase.kt
@@ -36,8 +36,10 @@ object CryptoSeedPhrase : IKotlinMatcher {
         RegexOption.MULTILINE
     )
 
+    private val WHITESPACE_SPLIT_REGEX = Regex("\\s+")
+
     override fun check(value: String): Boolean {
-        val words = value.trim().split(Regex("\\s+")).filter { it.isNotEmpty() }
+        val words = value.trim().split(WHITESPACE_SPLIT_REGEX).filter { it.isNotEmpty() }
         
         if (words.isEmpty()) return false
         

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/DODID.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/DODID.kt
@@ -70,10 +70,11 @@ object DODID : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val CHECK_DOD_ID_TEN_DIGITS_REGEX = Regex("""\d{10}""")
+
     override fun check(value: String): Boolean {
         // Extract 10-digit number from match (may include keywords)
-        val numberPattern = Regex("""\d{10}""")
-        val match = numberPattern.find(value)
+        val match = CHECK_DOD_ID_TEN_DIGITS_REGEX.find(value)
         if (match == null) return false
         
         val digits = match.value

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/DriverLicenseUS.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/DriverLicenseUS.kt
@@ -89,11 +89,18 @@ object DriverLicenseUS : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val CHECK_CO = Regex("""\d{2}-\d{3}-\d{4}""", RegexOption.IGNORE_CASE)
+    private val CHECK_FL = Regex("""[A-Z]-\d{3}-\d{3}-\d{3}-\d{3}""", RegexOption.IGNORE_CASE)
+    private val CHECK_ND = Regex("""[A-Z]{3}-\d{2}-\d{4}""", RegexOption.IGNORE_CASE)
+    private val CHECK_NJ = Regex("""[A-Z]\d{14}""", RegexOption.IGNORE_CASE)
+    private val CHECK_WA = Regex("""[A-Z]{3}\*\*[A-Z]{2}\d{3}[A-Z]\d""", RegexOption.IGNORE_CASE)
+    private val CHECK_WI = Regex("""[A-Z]\d{3}-\d{4}-\d{4}-\d{2}""", RegexOption.IGNORE_CASE)
+
     override fun check(value: String): Boolean {
         // Check match against one of the formats
         
         // Colorado: ##-###-####
-        if (value.matches(Regex("""\d{2}-\d{3}-\d{4}""", RegexOption.IGNORE_CASE))) {
+        if (value.matches(CHECK_CO)) {
             val digits = value.replace("-", "").filter { it.isDigit() }
             if (digits.length == 9 && !digits.all { it == '0' } && !digits.all { it == digits[0] }) {
                 return true
@@ -101,7 +108,7 @@ object DriverLicenseUS : IHyperMatcher, IKotlinMatcher {
         }
         
         // Florida: L-###-###-###-###
-        if (value.matches(Regex("""[A-Z]-\d{3}-\d{3}-\d{3}-\d{3}""", RegexOption.IGNORE_CASE))) {
+        if (value.matches(CHECK_FL)) {
             val digits = value.filter { it.isDigit() }
             if (digits.length == 12 && !digits.all { it == '0' } && !digits.all { it == digits[0] }) {
                 return true
@@ -109,7 +116,7 @@ object DriverLicenseUS : IHyperMatcher, IKotlinMatcher {
         }
         
         // North Dakota: ABC-12-3456
-        if (value.matches(Regex("""[A-Z]{3}-\d{2}-\d{4}""", RegexOption.IGNORE_CASE))) {
+        if (value.matches(CHECK_ND)) {
             val digits = value.filter { it.isDigit() }
             if (digits.length == 6 && !digits.all { it == '0' } && !digits.all { it == digits[0] }) {
                 return true
@@ -117,7 +124,7 @@ object DriverLicenseUS : IHyperMatcher, IKotlinMatcher {
         }
         
         // New Jersey: A + 14 digits
-        if (value.matches(Regex("""[A-Z]\d{14}""", RegexOption.IGNORE_CASE))) {
+        if (value.matches(CHECK_NJ)) {
             val digits = value.filter { it.isDigit() }
             if (digits.length == 14 && !digits.all { it == '0' } && !digits.all { it == digits[0] }) {
                 return true
@@ -125,7 +132,7 @@ object DriverLicenseUS : IHyperMatcher, IKotlinMatcher {
         }
         
         // Washington: DOE**MJ501P1
-        if (value.matches(Regex("""[A-Z]{3}\*\*[A-Z]{2}\d{3}[A-Z]\d""", RegexOption.IGNORE_CASE))) {
+        if (value.matches(CHECK_WA)) {
             val digits = value.filter { it.isDigit() }
             if (digits.length == 4 && !digits.all { it == '0' } && !digits.all { it == digits[0] }) {
                 return true
@@ -133,7 +140,7 @@ object DriverLicenseUS : IHyperMatcher, IKotlinMatcher {
         }
         
         // Wisconsin: J525-4209-0465-05
-        if (value.matches(Regex("""[A-Z]\d{3}-\d{4}-\d{4}-\d{2}""", RegexOption.IGNORE_CASE))) {
+        if (value.matches(CHECK_WI)) {
             val digits = value.filter { it.isDigit() }
             if (digits.length == 13 && !digits.all { it == '0' } && !digits.all { it == digits[0] }) {
                 return true

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/EIN.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/EIN.kt
@@ -128,14 +128,18 @@ object EIN : IHyperMatcher, IKotlinMatcher {
         }
     }
 
+    private val CHECK_NUMBER_PATTERN =
+        Regex("""(?:[07][1-7]|1[0-6]|2[0-7]|[35][0-9]|[468][0-8]|9[0-589])-?\d{7}""")
+    private val NON_DIGIT_HYPHEN_REGEX = Regex("[^0-9-]")
+    private val FORMAT_REGEX = Regex("""\d{2}-\d{7}""")
+
     override fun check(value: String): Boolean {
         // Extract EIN number from the match (may include keywords)
-        val numberPattern = Regex("""(?:[07][1-7]|1[0-6]|2[0-7]|[35][0-9]|[468][0-8]|9[0-589])-?\d{7}""")
-        val match = numberPattern.find(value)
+        val match = CHECK_NUMBER_PATTERN.find(value)
         if (match == null) return false
         
         // Extract only digits and hyphens from the matched number
-        val cleaned = match.value.replace(Regex("[^0-9-]"), "")
+        val cleaned = match.value.replace(NON_DIGIT_HYPHEN_REGEX, "")
         
         // Check format: must be digits, possibly with one hyphen
         val digitsOnly = cleaned.replace("-", "")
@@ -146,7 +150,7 @@ object EIN : IHyperMatcher, IKotlinMatcher {
         if (hyphenCount > 1) return false
         if (hyphenCount == 1) {
             // Hyphen must be after the first two digits
-            if (!cleaned.matches(Regex("""\d{2}-\d{7}"""))) return false
+            if (!cleaned.matches(FORMAT_REGEX)) return false
         }
         
         // Check prefix (first two digits of the entire number)

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/EducationDoc.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/EducationDoc.kt
@@ -125,8 +125,11 @@ object EducationDoc : IHyperMatcher, IKotlinMatcher {
         return true
     }
 
+    private val NON_DIGIT_REGEX = Regex("[^0-9]")
+    private val WHITESPACE_REGEX = Regex("\\s+")
+
     override fun check(value: String): Boolean {
-        val digits = value.replace(Regex("[^0-9]"), "")
+        val digits = value.replace(NON_DIGIT_REGEX, "")
         
         if (digits.isEmpty()) return false
         
@@ -141,9 +144,9 @@ object EducationDoc : IHyperMatcher, IKotlinMatcher {
 
         if (isRepeatingPattern(digits, 2) || isRepeatingPattern(digits, 3) || isRepeatingPattern(digits, 5)) return false
 
-        val parts = value.split(Regex("\\s+")).filter { it.isNotBlank() }
+        val parts = value.split(WHITESPACE_REGEX).filter { it.isNotBlank() }
         for (part in parts) {
-            val partDigits = part.replace(Regex("[^0-9]"), "")
+            val partDigits = part.replace(NON_DIGIT_REGEX, "")
             if (partDigits.length >= 6 && partDigits.all { it == partDigits[0] }) return false
         }
 

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/FullName.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/FullName.kt
@@ -29,19 +29,20 @@ object FullName : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val falseWords = setOf(
+        "Республика",
+        "Область",
+        "Край",
+        "Город",
+        "Село",
+        "Деревня",
+        "Улица",
+        "Проспект",
+        "Марий"
+    )
+
     override fun check(value: String): Boolean {
-        val falseList = listOf(
-            "Республика",
-            "Область",
-            "Край",
-            "Город",
-            "Село",
-            "Деревня",
-            "Улица",
-            "Проспект",
-            "Марий"
-        )
-        return !falseList.any { value.contains(it) }
+        return !falseWords.any { value.contains(it) }
     }
 
     override fun toString() = name

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/FullNameUS.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/FullNameUS.kt
@@ -55,6 +55,8 @@ object FullNameUS : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val WHITESPACE_REGEX = Regex("\\s+")
+
     override fun check(value: String): Boolean {
         if (value.any { it.isDigit() }) {
             return false
@@ -63,7 +65,7 @@ object FullNameUS : IHyperMatcher, IKotlinMatcher {
         // Remove leading and trailing punctuation marks and spaces
         val cleanedValue = value.trim().trimStart { it in "([{\"'" }.trimEnd { it in ")]}\"'" }
         
-        val words = cleanedValue.split(Regex("\\s+")).filter { it.isNotEmpty() && it != "." }
+        val words = cleanedValue.split(WHITESPACE_REGEX).filter { it.isNotEmpty() && it != "." }
         if (words.size < 2) return false
         
         val cities = setOf("new", "los", "san", "las", "washington", "ocean")

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/INN.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/INN.kt
@@ -49,8 +49,10 @@ object INN : IHyperMatcher, IKotlinMatcher {
         return true
     }
 
+    private val NON_DIGIT_REGEX = Regex("[^0-9]")
+
     override fun check(value: String): Boolean {
-        val inn = value.replace("[^0-9]".toRegex(), "")
+        val inn = value.replace(NON_DIGIT_REGEX, "")
         if (inn.length != 12) return false
         
         val zeroCount = inn.count { it == '0' }

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/ITIN.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/ITIN.kt
@@ -33,12 +33,15 @@ object ITIN : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val NON_DIGIT_HYPHEN_REGEX = Regex("[^0-9-]")
+    private val FORMAT_REGEX = Regex("""9[0-9]{2}-[7-8][0-9]-[0-9]{4}""")
+
     override fun check(value: String): Boolean {
         // Extract only digits and hyphens
-        val cleaned = value.replace(Regex("[^0-9-]"), "")
+        val cleaned = value.replace(NON_DIGIT_HYPHEN_REGEX, "")
         
         // Check format: must be digits with hyphens in format 9XX-7X-XXXX or 9XX-8X-XXXX
-        if (!cleaned.matches(Regex("""9[0-9]{2}-[7-8][0-9]-[0-9]{4}"""))) return false
+        if (!cleaned.matches(FORMAT_REGEX)) return false
         
         // Extract only digits for additional checks
         val digitsOnly = cleaned.replace("-", "")

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/LegalEntityId.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/LegalEntityId.kt
@@ -32,6 +32,8 @@ object LegalEntityId : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val WHITESPACE_STRIP_REGEX = Regex("\\s")
+
     override fun check(value: String): Boolean {
         // Normalize: strip leading/trailing non-alphanumeric wrappers (quotes, brackets, punctuation)
         var s = value.trim()
@@ -40,7 +42,7 @@ object LegalEntityId : IHyperMatcher, IKotlinMatcher {
 
         if (s.any { it.isLetter() && it.isLowerCase() }) return false
 
-        val cleanValue = s.replace(Regex("\\s"), "")
+        val cleanValue = s.replace(WHITESPACE_STRIP_REGEX, "")
         
         if (cleanValue.length == 20) {
             val body = cleanValue.substring(0, 18)

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/LegalEntityName.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/LegalEntityName.kt
@@ -62,6 +62,8 @@ object LegalEntityName : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val WHITESPACE_REGEX = Regex("[\\s]+")
+
     override fun check(value: String): Boolean {
         // Remove quotes and brackets from start and end for validation
         var text = value.trim()
@@ -78,7 +80,7 @@ object LegalEntityName : IHyperMatcher, IKotlinMatcher {
         if (text.any { !it.isLetter() && !it.isWhitespace() }) return false
         
         val legalEntityPrefixes = setOf("ооо", "пао", "зао", "нао", "ип", "фгуп", "гуп", "муп", "фонд", "ассоциация", "союз")
-        val words = text.split(Regex("[\\s]+")).filter { it.isNotBlank() }
+        val words = text.split(WHITESPACE_REGEX).filter { it.isNotBlank() }
         
         if (words.isEmpty()) return false
         

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/MedicareUS.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/MedicareUS.kt
@@ -53,8 +53,10 @@ object MedicareUS : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val NON_LETTER_OR_DIGIT_REGEX = Regex("[^A-Z0-9]")
+
     override fun check(value: String): Boolean {
-        val mbi = value.replace(Regex("[^A-Z0-9]"), "").uppercase().trim()
+        val mbi = value.replace(NON_LETTER_OR_DIGIT_REGEX, "").uppercase().trim()
 
         if (mbi.length != 11)
             return false

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/MilitaryID.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/MilitaryID.kt
@@ -99,14 +99,17 @@ object MilitaryID : IHyperMatcher, IKotlinMatcher {
         return true
     }
 
+    private val CHECK_MILITARY_NUMBER_PATTERN =
+        Regex("[А-ЯA-Z]{2}[\\s№\\-]*\\d{7}")
+    private val NON_CYRILLIC_LETTER_DIGIT_REGEX = Regex("[^А-Яа-я0-9]")
+
     override fun check(value: String): Boolean {
         // Extract only the number (2 letters + 7 digits) from the match
         // The match may include keywords, so we search for the number pattern
-        val numberPattern = Regex("[А-ЯA-Z]{2}[\\s№\\-]*\\d{7}")
-        val match = numberPattern.find(value)
+        val match = CHECK_MILITARY_NUMBER_PATTERN.find(value)
         if (match == null) return false
         
-        val cleaned = match.value.replace(Regex("[^А-Яа-я0-9]"), "").uppercase()
+        val cleaned = match.value.replace(NON_CYRILLIC_LETTER_DIGIT_REGEX, "").uppercase()
         
         if (cleaned.length != 9)
             return false

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/NSN.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/NSN.kt
@@ -99,10 +99,11 @@ object NSN : IHyperMatcher, IKotlinMatcher {
         return true
     }
 
+    private val CHECK_NUMBER_PATTERN = Regex("""(?:\d{13}|\d{4}-\d{2}-\d{3}-\d{4})""")
+
     override fun check(value: String): Boolean {
         // Extract NSN number from the match (may include keywords)
-        val numberPattern = Regex("""(?:\d{13}|\d{4}-\d{2}-\d{3}-\d{4})""")
-        val match = numberPattern.find(value)
+        val match = CHECK_NUMBER_PATTERN.find(value)
         if (match == null) return false
         
         // Extract only digits (remove hyphens and other characters)

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/OGRNIP.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/OGRNIP.kt
@@ -77,12 +77,14 @@ object OGRNIP : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val CHECK_OGRNIP_NUMBER_REGEX = Regex("[34]\\d{14}")
+    private val CHECK_NON_DIGIT_STRIP_REGEX = Regex("[^\\d]")
+
     override fun check(value: String): Boolean {
-        val numberPattern = Regex("[34]\\d{14}")
-        val match = numberPattern.find(value)
+        val match = CHECK_OGRNIP_NUMBER_REGEX.find(value)
         if (match == null) return false
         
-        val ogrnipClean = match.value.replace(Regex("[^\\d]"), "")
+        val ogrnipClean = match.value.replace(CHECK_NON_DIGIT_STRIP_REGEX, "")
         if (ogrnipClean.length != 15) return false
         val digits = ogrnipClean.map { it.toString().toInt() }
         val bigNum = ogrnipClean.substring(0, 14).toLong()

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/OKPO.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/OKPO.kt
@@ -79,6 +79,8 @@ object OKPO : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val CHECK_OKPO_NUMBER_CAPTURE_REGEX = Regex("""(\d{8}|\d{10})""")
+
     private fun isSequential(digits: String, ascending: Boolean): Boolean {
         for (i in 1 until digits.length) {
             val current = digits[i].digitToInt()
@@ -103,8 +105,7 @@ object OKPO : IHyperMatcher, IKotlinMatcher {
 
     override fun check(value: String): Boolean {
         // Extract OKPO number from the value (which may contain keywords)
-        val numberPattern = Regex("""(\d{8}|\d{10})""")
-        val match = numberPattern.find(value) ?: return false
+        val match = CHECK_OKPO_NUMBER_CAPTURE_REGEX.find(value) ?: return false
         val okpoClean = match.value
         val length = okpoClean.length
         if (length != 8 && length != 10) return false

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/OMS.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/OMS.kt
@@ -82,8 +82,10 @@ object OMS : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val NON_DIGIT_REGEX = Regex("""\D""")
+
     override fun check(value: String): Boolean {
-        val oms = value.replace("""\D""".toRegex(), "")
+        val oms = value.replace(NON_DIGIT_REGEX, "")
         
         if (oms.length != 16) return false
         

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/OSAGOPolicy.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/OSAGOPolicy.kt
@@ -77,13 +77,15 @@ object OSAGOPolicy : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val CHECK_POLICY_NUMBER_REGEX = Regex("[A-ZА-Я]{3}\\s+№?\\s*\\d{10}")
+    private val CHECK_NON_ALPHANUMERIC_STRIP_REGEX = Regex("[^A-Za-z0-9]")
+
     override fun check(value: String): Boolean {
         // Extract only the OSAGO policy number from the match (may include keywords)
-        val numberPattern = Regex("[A-ZА-Я]{3}\\s+№?\\s*\\d{10}")
-        val match = numberPattern.find(value)
+        val match = CHECK_POLICY_NUMBER_REGEX.find(value)
         if (match == null) return false
         
-        val cleaned = match.value.replace(Regex("[^A-Za-z0-9]"), "").uppercase()
+        val cleaned = match.value.replace(CHECK_NON_ALPHANUMERIC_STRIP_REGEX, "").uppercase()
         
         if (cleaned.length != 13) return false
         

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/Passport.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/Passport.kt
@@ -62,10 +62,11 @@ object Passport : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val CHECK_NUMBER_PATTERN = Regex("""([0-9]{2})[ \t-]?([0-9]{2})[ \t-]?([0-9]{6})""")
+
     override fun check(value: String): Boolean {
         // Extract passport series and number
-        val numberPattern = Regex("""([0-9]{2})[ \t-]?([0-9]{2})[ \t-]?([0-9]{6})""")
-        val match = numberPattern.find(value) ?: return false
+        val match = CHECK_NUMBER_PATTERN.find(value) ?: return false
         
         val series1 = match.groupValues[1]
         val series2 = match.groupValues[2]

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/PassportUS.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/PassportUS.kt
@@ -54,13 +54,15 @@ object PassportUS : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val CHECK_PASSPORT_NUMBER_REGEX = Regex("[A-Z][0-9]{8}")
+    private val CHECK_PASSPORT_NON_ALPHANUMERIC_STRIP_REGEX = Regex("[^A-Z0-9]")
+
     override fun check(value: String): Boolean {
         // Extract passport number from the match (may include keywords)
-        val numberPattern = Regex("[A-Z][0-9]{8}")
-        val match = numberPattern.find(value)
+        val match = CHECK_PASSPORT_NUMBER_REGEX.find(value)
         if (match == null) return false
         
-        val cleaned = match.value.replace(Regex("[^A-Z0-9]"), "").uppercase()
+        val cleaned = match.value.replace(CHECK_PASSPORT_NON_ALPHANUMERIC_STRIP_REGEX, "").uppercase()
 
         if (cleaned.length != 9) return false
 

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/PhoneUS.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/PhoneUS.kt
@@ -66,11 +66,13 @@ object PhoneUS : IHyperMatcher, IKotlinMatcher {
         "421", "423", "395", "342", "863", "861",
         "472", "473", "474", "475", "481", "482",
         "483", "484", "485", "486", "487", "491",
-        "492", "493", "494", "800", "900"
+        "492", "493", "494",         "800", "900"
     )
 
+    private val NON_DIGIT_REGEX = Regex("[^0-9]")
+
     override fun check(value: String): Boolean {
-        var digits = value.replace(Regex("[^0-9]"), "")
+        var digits = value.replace(NON_DIGIT_REGEX, "")
         
         if (digits.length == 11 && digits.startsWith("1")) {
             digits = digits.substring(1)

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/RIN.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/RIN.kt
@@ -33,8 +33,10 @@ object RIN : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val NON_DIGIT_X_REGEX = Regex("[^0-9Xx]")
+
     override fun check(value: String): Boolean {
-        val cleaned = value.replace(Regex("[^0-9Xx]"), "").uppercase()
+        val cleaned = value.replace(NON_DIGIT_X_REGEX, "").uppercase()
 
         if (cleaned.length == 18) {
             return validateChineseId(cleaned)

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/ResidencePermit.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/ResidencePermit.kt
@@ -78,14 +78,16 @@ object ResidencePermit : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val CHECK_RESIDENCE_NUMBER_REGEX = Regex("""(?:82|83)\s*(?:№|N)?\s*(\d{7})""")
+    private val CHECK_RESIDENCE_SERIES_REGEX = Regex("""(82|83)""")
+
     override fun check(value: String): Boolean {
         // Extract residence permit number from the value (which may contain keywords)
-        val numberPattern = Regex("""(?:82|83)\s*(?:№|N)?\s*(\d{7})""")
-        val match = numberPattern.find(value) ?: return false
+        val match = CHECK_RESIDENCE_NUMBER_REGEX.find(value) ?: return false
         val numberPart = match.groupValues[1]
         
         // Form the full number: series + number
-        val seriesMatch = Regex("""(82|83)""").find(value)
+        val seriesMatch = CHECK_RESIDENCE_SERIES_REGEX.find(value)
         val series = seriesMatch?.value ?: return false
         
         val cleaned = series + numberPart

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/SNILS.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/SNILS.kt
@@ -103,16 +103,18 @@ object SNILS : IHyperMatcher, IKotlinMatcher {
         return true
     }
 
+    private val CHECK_NUMBER_PATTERN = Regex("([0-9]{3}[\\s\\-]?[0-9]{3}[\\s\\-]?[0-9]{3}[\\s\\-]?[0-9]{2}|[0-9]{11})")
+    private val SNILS_SANITIZE_REGEX = Regex("[^0-9 -]")
+
     override fun check(value: String): Boolean {
         if(value.length <= 2)
             return false
         var summ = 0
         // Extract only the SNILS number from the match (may include keywords)
-        val numberPattern = Regex("([0-9]{3}[\\s\\-]?[0-9]{3}[\\s\\-]?[0-9]{3}[\\s\\-]?[0-9]{2}|[0-9]{11})")
-        val match = numberPattern.find(value)
+        val match = CHECK_NUMBER_PATTERN.find(value)
         if (match == null) return false
         
-        val snils = match.value.replace(Regex("[^0-9 -]"), "").replace(" ", "").replace("-", "").trim()
+        val snils = match.value.replace(SNILS_SANITIZE_REGEX, "").replace(" ", "").replace("-", "").trim()
 
         if (snils.length != 11)
             return false

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/SSN.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/SSN.kt
@@ -37,8 +37,10 @@ object SSN : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val NON_DIGIT_REGEX = Regex("[^0-9]")
+
     override fun check(value: String): Boolean {
-        val ssn = value.replace(Regex("[^0-9]"), "").trim()
+        val ssn = value.replace(NON_DIGIT_REGEX, "").trim()
 
         if (ssn.length != 9) return false
 

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/SocialUserId.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/SocialUserId.kt
@@ -43,9 +43,10 @@ object SocialUserId : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val USERNAME_CAPTURE_PATTERN = Regex("""@([a-zA-Z0-9_]{3,32})""")
+
     override fun check(value: String): Boolean {
-        val usernamePattern = Regex("""@([a-zA-Z0-9_]{3,32})""")
-        val match = usernamePattern.find(value) ?: return false
+        val match = USERNAME_CAPTURE_PATTERN.find(value) ?: return false
         val username = match.groupValues[1].lowercase()
         
         val cssAtRules = setOf(

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/TCN.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/TCN.kt
@@ -73,10 +73,11 @@ object TCN : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val CHECK_TCN_ALPHANUMERIC_17_REGEX = Regex("""[A-Z0-9]{17}""", RegexOption.IGNORE_CASE)
+
     override fun check(value: String): Boolean {
         // Extract 17-character number from match (may include keyword and separators)
-        val numberPattern = Regex("""[A-Z0-9]{17}""", RegexOption.IGNORE_CASE)
-        val match = numberPattern.find(value)
+        val match = CHECK_TCN_ALPHANUMERIC_17_REGEX.find(value)
         if (match == null) return false
         
         val tcn = match.value.uppercase()

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/VIN.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/VIN.kt
@@ -30,8 +30,10 @@ object VIN : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val NON_VIN_CHARACTER_REGEX = Regex("[^A-HJ-NPR-Z0-9]")
+
     override fun check(value: String): Boolean {
-        val cleaned = value.replace(Regex("[^A-HJ-NPR-Z0-9]"), "").uppercase()
+        val cleaned = value.replace(NON_VIN_CHARACTER_REGEX, "").uppercase()
         
         if (cleaned.length != 17) return false
         

--- a/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/VisaNumberUS.kt
+++ b/kotlin-lib/src/commonMain/kotlin/org/angryscan/common/matchers/VisaNumberUS.kt
@@ -78,6 +78,9 @@ object VisaNumberUS : IHyperMatcher, IKotlinMatcher {
         ExpressionOption.UTF8
     )
 
+    private val CHECK_VISA_NUMBER_8_DIGITS_REGEX = Regex("""\d{8}""")
+    private val CHECK_VISA_NUMBER_LETTER_7_DIGITS_REGEX = Regex("""[A-Z]\d{7}""", RegexOption.IGNORE_CASE)
+
     private fun isSequential(digits: String, ascending: Boolean): Boolean {
         for (i in 1 until digits.length) {
             val current = digits[i].digitToInt()
@@ -140,11 +143,8 @@ object VisaNumberUS : IHyperMatcher, IKotlinMatcher {
     override fun check(value: String): Boolean {
         // Extract visa number from the match (may include keywords)
         // Try to find the number pattern in the value
-        val numberPattern8Digits = Regex("""\d{8}""")
-        val numberPatternLetter7Digits = Regex("""[A-Z]\d{7}""", RegexOption.IGNORE_CASE)
-        
-        val match8Digits = numberPattern8Digits.find(value)
-        val matchLetter7Digits = numberPatternLetter7Digits.find(value)
+        val match8Digits = CHECK_VISA_NUMBER_8_DIGITS_REGEX.find(value)
+        val matchLetter7Digits = CHECK_VISA_NUMBER_LETTER_7_DIGITS_REGEX.find(value)
         
         val number = when {
             match8Digits != null -> match8Digits.value.uppercase()

--- a/kotlin-lib/src/jsMain/kotlin/org/angryscan/common/constants/CardBins.js.kt
+++ b/kotlin-lib/src/jsMain/kotlin/org/angryscan/common/constants/CardBins.js.kt
@@ -1,8 +1,8 @@
 package org.angryscan.common.constants
 
 actual object CardBins {
-    actual val cardBins: List<String>
-        get() = listOf(
+    actual val cardBins: Set<String>
+        get() = setOf(
             "3528",
             "3530",
             "3531",

--- a/kotlin-lib/src/jvmMain/kotlin/org/angryscan/common/constants/CardBins.kt
+++ b/kotlin-lib/src/jvmMain/kotlin/org/angryscan/common/constants/CardBins.kt
@@ -5,10 +5,10 @@ import java.io.InputStreamReader
 
 actual object CardBins {
     private const val BINS_FILE_NAME = "values/CardBins.txt"
-    actual val cardBins: List<String> = (
+    actual val cardBins: Set<String> = (
             this::class.java.classLoader.getResourceAsStream(BINS_FILE_NAME)
                 ?: throw IllegalArgumentException("$BINS_FILE_NAME is not found")
             ).use { inputStream ->
-            BufferedReader(InputStreamReader(inputStream)).readLines()
+            BufferedReader(InputStreamReader(inputStream)).readLines().toSet()
         }
 }

--- a/kotlin-lib/src/jvmMain/kotlin/org/angryscan/common/engine/hyperscan/HyperScanEngine.kt
+++ b/kotlin-lib/src/jvmMain/kotlin/org/angryscan/common/engine/hyperscan/HyperScanEngine.kt
@@ -64,7 +64,6 @@ class HyperScanEngine(
             .filter {
                 expressions[it.matchedExpression]!!.check(it.matchedString)
             }
-            .toMutableList()
 
         return res.map {
             Match(

--- a/kotlin-lib/src/jvmMain/kotlin/org/angryscan/common/engine/hyperscan/HyperScanEngine.kt
+++ b/kotlin-lib/src/jvmMain/kotlin/org/angryscan/common/engine/hyperscan/HyperScanEngine.kt
@@ -9,6 +9,8 @@ import kotlinx.serialization.Transient
 import org.angryscan.common.engine.IScanEngine
 import org.angryscan.common.engine.Match
 import org.angryscan.common.extensions.toExpressionFlag
+import java.io.*
+import java.security.MessageDigest
 import java.util.*
 
 @Serializable
@@ -17,52 +19,31 @@ class HyperScanEngine(
     private val requireKeywords: Boolean = true
 ) : IScanEngine {
     @Transient
-    private val expressions =
-        matchers
-            .flatMap { ip ->
-                ip.getHyperPatterns(requireKeywords).map { hp ->
-                    hp to ip
-                }
-            }.mapIndexed { index, pair ->
-                //Конвертируем набор опций
-                val es = EnumSet.of(ExpressionFlag.SOM_LEFTMOST)
-
-                pair.second.expressionOptions.forEach {
-                    es.add(it.toExpressionFlag())
-                }
-
-                //Создаем выражения для поиска
-                val expr = Expression(
-                    pair.first,
-                    es,
-                    index
-                )
-
-                // Проверяем выражения
-                val validate = expr.validate()
-                if (!validate.isValid)
-                    throw Exception("Not valid pattern: ${pair.first}")
-
-                expr to pair.second //Результат с возможностью обратного преобразования
-            }.associate { it.first to it.second }
+    private val expressionEntries: List<Pair<Expression, IHyperMatcher>> =
+        buildExpressionEntries(matchers, requireKeywords)
 
     @Transient
-    private val database = Database.compile(expressions.keys.toList())
+    private val matcherByExpressionId: Map<Int, IHyperMatcher> =
+        expressionEntries.associate { (expr, matcher) -> expr.id to matcher }
+
     @Transient
-    private val scanner = Scanner().also {
+    private var database: Database = preloadedDatabase.get()
+        ?: Database.compile(expressionEntries.map { it.first })
+
+    @Transient
+    private var scanner: Scanner = Scanner().also {
         it.allocScratch(database)
     }
 
     override fun scan(text: String): List<Match> {
+        val normalizedText = text
+            .replace("\u0000", "")
+            .replace('\u000B', '\n')
+
         val res = scanner
-            .scan(
-                database,
-                text
-                    .replace("\u0000", "")
-                    .replace('\u000B', '\n')
-            )
+            .scan(database, normalizedText)
             .filter {
-                expressions[it.matchedExpression]!!.check(it.matchedString)
+                matcherByExpressionId[it.matchedExpression.id]!!.check(it.matchedString)
             }
 
         return res.map {
@@ -78,7 +59,7 @@ class HyperScanEngine(
                 ),
                 startPosition = it.startPosition,
                 endPosition = it.endPosition,
-                matcher = expressions[it.matchedExpression]!!
+                matcher = matcherByExpressionId[it.matchedExpression.id]!!
             )
         }.distinct()
     }
@@ -86,5 +67,167 @@ class HyperScanEngine(
     override fun close() {
         scanner.close()
         database.close()
+    }
+
+    /**
+     * Serializes the compiled database with a compatibility manifest.
+     * The returned bytes can later be passed to [fromCompiledDatabase] for fast initialization.
+     */
+    fun saveCompiledDatabase(): ByteArray {
+        val baos = ByteArrayOutputStream()
+        saveCompiledDatabase(baos)
+        return baos.toByteArray()
+    }
+
+    /**
+     * Serializes the compiled database to the given [output] stream.
+     * The stream is NOT closed by this method.
+     */
+    fun saveCompiledDatabase(output: OutputStream) {
+        val dos = DataOutputStream(output)
+        dos.write(MAGIC)
+        dos.writeInt(FORMAT_VERSION)
+        val signature = computeSignature(matchers, requireKeywords)
+        dos.writeInt(signature.size)
+        dos.write(signature)
+        database.save(dos)
+        dos.flush()
+    }
+
+    /**
+     * Serializes the compiled database to the given [file].
+     */
+    fun saveCompiledDatabase(file: File) {
+        file.outputStream().buffered().use { saveCompiledDatabase(it) }
+    }
+
+    companion object {
+        private val MAGIC = "HSCE".toByteArray(Charsets.US_ASCII)
+        private const val FORMAT_VERSION = 1
+
+        // ThreadLocal used by factory methods to inject a pre-loaded Database
+        // into the primary constructor path, avoiding redundant compilation.
+        private val preloadedDatabase = ThreadLocal<Database?>()
+
+        /**
+         * Creates an engine from a previously saved compiled database ([ByteArray]).
+         *
+         * @throws IllegalArgumentException if the data is corrupted, has wrong format,
+         *   or is incompatible with the provided [matchers]/[requireKeywords] configuration.
+         */
+        fun fromCompiledDatabase(
+            matchers: List<IHyperMatcher>,
+            compiledDatabase: ByteArray,
+            requireKeywords: Boolean = true
+        ): HyperScanEngine =
+            fromCompiledDatabase(matchers, ByteArrayInputStream(compiledDatabase), requireKeywords)
+
+        /**
+         * Creates an engine from a previously saved compiled database ([InputStream]).
+         * The stream is NOT closed by this method.
+         */
+        fun fromCompiledDatabase(
+            matchers: List<IHyperMatcher>,
+            input: InputStream,
+            requireKeywords: Boolean = true
+        ): HyperScanEngine {
+            val buffered = if (input.markSupported()) input else BufferedInputStream(input)
+            val dis = DataInputStream(buffered)
+
+            val magic = ByteArray(4)
+            dis.readFully(magic)
+            if (!magic.contentEquals(MAGIC))
+                throw IllegalArgumentException(
+                    "Invalid compiled database format: wrong magic bytes"
+                )
+
+            val version = dis.readInt()
+            if (version != FORMAT_VERSION)
+                throw IllegalArgumentException(
+                    "Unsupported compiled database format version: $version"
+                )
+
+            val expectedSignature = computeSignature(matchers, requireKeywords)
+
+            val sigLen = dis.readInt()
+            if (sigLen != expectedSignature.size)
+                throw IllegalArgumentException(
+                    "Invalid compiled database format: unexpected signature length $sigLen (expected ${expectedSignature.size})"
+                )
+
+            val storedSignature = ByteArray(sigLen)
+            dis.readFully(storedSignature)
+
+            if (!storedSignature.contentEquals(expectedSignature))
+                throw IllegalArgumentException(
+                    "Compiled database is incompatible with the provided matchers/requireKeywords configuration"
+                )
+
+            val loadedDb = Database.load(dis)
+
+            preloadedDatabase.set(loadedDb)
+            try {
+                return HyperScanEngine(matchers, requireKeywords)
+            } catch (e: Throwable) {
+                loadedDb.close()
+                throw e
+            } finally {
+                preloadedDatabase.remove()
+            }
+        }
+
+        /**
+         * Creates an engine from a previously saved compiled database ([File]).
+         */
+        fun fromCompiledDatabase(
+            matchers: List<IHyperMatcher>,
+            file: File,
+            requireKeywords: Boolean = true
+        ): HyperScanEngine =
+            file.inputStream().buffered().use {
+                fromCompiledDatabase(matchers, it, requireKeywords)
+            }
+
+        internal fun buildExpressionEntries(
+            matchers: List<IHyperMatcher>,
+            requireKeywords: Boolean
+        ): List<Pair<Expression, IHyperMatcher>> =
+            matchers
+                .flatMap { matcher ->
+                    matcher.getHyperPatterns(requireKeywords).map { pattern ->
+                        pattern to matcher
+                    }
+                }
+                .mapIndexed { index, (pattern, matcher) ->
+                    val flags = EnumSet.of(ExpressionFlag.SOM_LEFTMOST)
+                    matcher.expressionOptions.forEach { flags.add(it.toExpressionFlag()) }
+
+                    val expr = Expression(pattern, flags, index)
+                    val validate = expr.validate()
+                    if (!validate.isValid)
+                        throw Exception("Not valid pattern: $pattern")
+
+                    expr to matcher
+                }
+
+        internal fun computeSignature(
+            matchers: List<IHyperMatcher>,
+            requireKeywords: Boolean
+        ): ByteArray {
+            val md = MessageDigest.getInstance("SHA-256")
+            md.update(if (requireKeywords) 1.toByte() else 0.toByte())
+            matchers.forEach { matcher ->
+                matcher.getHyperPatterns(requireKeywords).forEach { pattern ->
+                    md.update(pattern.toByteArray(Charsets.UTF_8))
+                    md.update(0)
+                    matcher.expressionOptions.sortedBy { it.ordinal }.forEach { opt ->
+                        md.update(opt.name.toByteArray(Charsets.UTF_8))
+                        md.update(1)
+                    }
+                    md.update(2)
+                }
+            }
+            return md.digest()
+        }
     }
 }

--- a/kotlin-lib/src/jvmTest/kotlin/org/angryscan/common/BenchmarkTest.kt
+++ b/kotlin-lib/src/jvmTest/kotlin/org/angryscan/common/BenchmarkTest.kt
@@ -134,10 +134,14 @@ internal class BenchmarkTest {
         println("║  Warmup: $SCAN_WARMUP iters   Measure: $SCAN_MEASURE iters")
         println("╚══════════════════════════════════════════════════════════════════════╝")
 
+        val compiledDb = HyperScanEngine(hyperMatchers).use { it.saveCompiledDatabase() }
+
         val kotlinStats: Stats
         val hyperStats:  Stats
-        var kotlinMatches = 0
-        var hyperMatches  = 0
+        val preloadStats: Stats
+        var kotlinMatches  = 0
+        var hyperMatches   = 0
+        var preloadMatches = 0
 
         KotlinEngine(kotlinMatchers).use { engine ->
             print("  KotlinEngine    warming up... "); System.out.flush()
@@ -157,9 +161,19 @@ internal class BenchmarkTest {
             hyperStats = times.stats()
         }
 
+        HyperScanEngine.fromCompiledDatabase(hyperMatchers, compiledDb).use { engine ->
+            print("  Hyper(preload)  warming up... "); System.out.flush()
+            repeat(SCAN_WARMUP) { engine.scan(corpus) }
+            println("done")
+            val times = LongArray(SCAN_MEASURE)
+            repeat(SCAN_MEASURE) { i -> times[i] = measureNanoTime { preloadMatches += engine.scan(corpus).size } }
+            preloadStats = times.stats()
+        }
+
         println("  --- results ---")
-        kotlinStats.printScan("KotlinEngine",   corpus.length, kotlinMatches / SCAN_MEASURE)
-        hyperStats.printScan("HyperScanEngine", corpus.length, hyperMatches  / SCAN_MEASURE)
+        kotlinStats.printScan("KotlinEngine",    corpus.length, kotlinMatches  / SCAN_MEASURE)
+        hyperStats.printScan("HyperScanEngine",  corpus.length, hyperMatches   / SCAN_MEASURE)
+        preloadStats.printScan("Hyper(preload)",  corpus.length, preloadMatches / SCAN_MEASURE)
         println()
 
         writeReport("benchmark-scan.md", buildString {
@@ -171,8 +185,9 @@ internal class BenchmarkTest {
             appendLine()
             appendLine("| Engine | mean | p50 | σ | Throughput | Matches/iter |")
             appendLine("|:---|---:|---:|---:|---:|---:|")
-            appendLine(kotlinStats.mdScanRow("KotlinEngine",   corpus.length, kotlinMatches / SCAN_MEASURE))
-            appendLine(hyperStats.mdScanRow("HyperScanEngine", corpus.length, hyperMatches  / SCAN_MEASURE))
+            appendLine(kotlinStats.mdScanRow("KotlinEngine",      corpus.length, kotlinMatches  / SCAN_MEASURE))
+            appendLine(hyperStats.mdScanRow("HyperScanEngine",    corpus.length, hyperMatches   / SCAN_MEASURE))
+            appendLine(preloadStats.mdScanRow("HyperScan(preload)", corpus.length, preloadMatches / SCAN_MEASURE))
         })
     }
 
@@ -190,12 +205,20 @@ internal class BenchmarkTest {
         println("║  Warmup: $INIT_WARMUP iters   Measure: $INIT_MEASURE iters")
         println("╚══════════════════════════════════════════════════════════════════════╝")
 
-        val kotlinStats = measureInit("KotlinEngine   ") { KotlinEngine(kotlinMatchers).also { it.close() } }
-        val hyperStats  = measureInit("HyperScanEngine") { HyperScanEngine(hyperMatchers).also { it.close() } }
+        val compiledDb = HyperScanEngine(hyperMatchers).use { it.saveCompiledDatabase() }
+
+        val kotlinStats   = measureInit("KotlinEngine   ") { KotlinEngine(kotlinMatchers).also { it.close() } }
+        val hyperStats    = measureInit("HyperScanEngine") { HyperScanEngine(hyperMatchers).also { it.close() } }
+        val preloadStats  = measureInit("Hyper(preload) ") {
+            HyperScanEngine.fromCompiledDatabase(hyperMatchers, compiledDb).also { it.close() }
+        }
 
         println("  --- results ---")
         kotlinStats.printInit("KotlinEngine")
         hyperStats.printInit("HyperScanEngine")
+        preloadStats.printInit("Hyper(preload)")
+        val speedup = if (preloadStats.mean > 0) hyperStats.mean / preloadStats.mean else Double.NaN
+        println("  Pre-compiled DB speedup: %.1fx".format(speedup))
         println()
 
         writeReport("benchmark-init.md", buildString {
@@ -207,6 +230,9 @@ internal class BenchmarkTest {
             appendLine("|:---|---:|---:|---:|---:|---:|")
             appendLine(kotlinStats.mdInitRow("KotlinEngine"))
             appendLine(hyperStats.mdInitRow("HyperScanEngine"))
+            appendLine(preloadStats.mdInitRow("HyperScan(preload)"))
+            appendLine()
+            appendLine("_Pre-compiled DB speedup: **%.1fx**_".format(speedup))
         })
     }
 
@@ -234,15 +260,22 @@ internal class BenchmarkTest {
         assertNotNull(resource, "testText.txt not found")
         val text = java.io.File(resource.file).readText()
 
-        val kotlinCount = KotlinEngine(kotlinMatchers).use { it.scan(text).size }
-        val hyperCount  = HyperScanEngine(hyperMatchers).use { it.scan(text).size }
+        val compiledDb = HyperScanEngine(hyperMatchers).use { it.saveCompiledDatabase() }
+
+        val kotlinCount  = KotlinEngine(kotlinMatchers).use { it.scan(text).size }
+        val hyperCount   = HyperScanEngine(hyperMatchers).use { it.scan(text).size }
+        val preloadCount = HyperScanEngine.fromCompiledDatabase(hyperMatchers, compiledDb).use { it.scan(text).size }
 
         println("\n  Consistency check on testText.txt:")
-        println("  KotlinEngine    → $kotlinCount matches")
-        println("  HyperScanEngine → $hyperCount matches")
+        println("  KotlinEngine       → $kotlinCount matches")
+        println("  HyperScanEngine    → $hyperCount matches")
+        println("  Hyper(preload)     → $preloadCount matches")
+
         val note = if (kotlinCount == hyperCount) "equal"
                    else "delta=${hyperCount - kotlinCount} (expected — see EngineTest for known differences)"
-        println("  Result: $note")
+        val preloadNote = if (hyperCount == preloadCount) "preload matches compile"
+                          else "MISMATCH: preload=$preloadCount vs compile=$hyperCount"
+        println("  Result: $note  |  $preloadNote")
 
         writeReport("benchmark-consistency.md", buildString {
             appendLine("### Match Consistency (`testText.txt`)")
@@ -251,8 +284,9 @@ internal class BenchmarkTest {
             appendLine("|:---|---:|")
             appendLine("| `KotlinEngine` | $kotlinCount |")
             appendLine("| `HyperScanEngine` | $hyperCount |")
+            appendLine("| `HyperScan(preload)` | $preloadCount |")
             appendLine()
-            appendLine("_${note}_")
+            appendLine("_${note}_ | _${preloadNote}_")
         })
     }
 }

--- a/kotlin-lib/src/jvmTest/kotlin/org/angryscan/common/BenchmarkTest.kt
+++ b/kotlin-lib/src/jvmTest/kotlin/org/angryscan/common/BenchmarkTest.kt
@@ -1,0 +1,258 @@
+package org.angryscan.common
+
+import org.angryscan.common.engine.hyperscan.HyperScanEngine
+import org.angryscan.common.engine.hyperscan.IHyperMatcher
+import org.angryscan.common.engine.kotlin.IKotlinMatcher
+import org.angryscan.common.engine.kotlin.KotlinEngine
+import org.angryscan.common.extensions.Matchers
+import kotlin.math.sqrt
+import kotlin.system.measureNanoTime
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/**
+ * Benchmark for KotlinEngine and HyperScanEngine.
+ *
+ * Covers:
+ *  1. Scan throughput — both engines on a representative text corpus.
+ *  2. Init speed      — engine creation time.
+ *  3. Consistency     — match count comparison between engines.
+ *
+ * Results are written to build/reports/benchmark-*.md and combined by CI
+ * into a single PR comment (see .github/workflows/Tests.yml).
+ *
+ * Run locally:
+ *   ./gradlew :kotlin-lib:jvmTest --tests "*BenchmarkTest*" --info
+ */
+internal class BenchmarkTest {
+
+    // ── Configuration ──────────────────────────────────────────────────────────
+
+    private val kotlinMatchers = Matchers.filterIsInstance<IKotlinMatcher>()
+    private val hyperMatchers  = Matchers.filterIsInstance<IHyperMatcher>()
+
+    companion object {
+        private const val SCAN_WARMUP  = 5
+        private const val SCAN_MEASURE = 20
+
+        private const val INIT_WARMUP  = 1
+        private const val INIT_MEASURE = 5
+
+        /** Repeat base corpus to produce ~500 KB representative of real-world PII data. */
+        private const val CORPUS_REPEAT = 250
+
+        private val reportDir get() = java.io.File(System.getProperty("user.dir"), "build/reports")
+    }
+
+    // ── Text corpus ────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a corpus from testText.txt — covers the widest variety of matchers:
+     * email, phone, passport, SNILS, card number, INN, OMS, address, login, password,
+     * IPv4/IPv6, full name, birthday, driver license, education doc, and more.
+     */
+    private fun buildCorpus(): String {
+        val resource = javaClass.getResource("/testFiles/testText.txt")
+            ?: error("testFiles/testText.txt not found in test resources")
+        val base = java.io.File(resource.file).readText()
+        return buildString(base.length * CORPUS_REPEAT + CORPUS_REPEAT) {
+            repeat(CORPUS_REPEAT) { append(base); append('\n') }
+        }
+    }
+
+    // ── Statistics ─────────────────────────────────────────────────────────────
+
+    private data class Stats(
+        val mean: Double, val stddev: Double,
+        val min: Double,  val max: Double,
+        val p50: Double
+    )
+
+    private fun LongArray.stats(): Stats {
+        val ms     = map { it / 1_000_000.0 }
+        val mean   = ms.average()
+        val stddev = sqrt(ms.map { (it - mean) * (it - mean) }.average())
+        val sorted = ms.sorted()
+        return Stats(
+            mean   = mean,
+            stddev = stddev,
+            min    = sorted.first(),
+            max    = sorted.last(),
+            p50    = sorted[size / 2]
+        )
+    }
+
+    // ── Console helpers ────────────────────────────────────────────────────────
+
+    private fun Stats.printScan(label: String, textBytes: Int, matchesPerIter: Int) {
+        val throughput = (textBytes.toDouble() / 1024 / 1024) / (mean / 1000.0)
+        println(
+            "  %-18s  mean=%6.1f ms  p50=%6.1f  σ=%5.1f  throughput=%5.2f MB/s  matches=%d"
+                .format(label, mean, p50, stddev, throughput, matchesPerIter)
+        )
+    }
+
+    private fun Stats.printInit(label: String) {
+        println(
+            "  %-18s  mean=%6.1f ms  p50=%6.1f  min=%6.1f  max=%6.1f  σ=%5.1f"
+                .format(label, mean, p50, min, max, stddev)
+        )
+    }
+
+    // ── Markdown helpers ───────────────────────────────────────────────────────
+
+    private fun Stats.mdScanRow(label: String, textBytes: Int, matchesPerIter: Int): String {
+        val tp = (textBytes.toDouble() / 1024 / 1024) / (mean / 1000.0)
+        return "| `$label` | %.1f ms | %.1f | %.1f | %.2f MB/s | %d |"
+            .format(mean, p50, stddev, tp, matchesPerIter)
+    }
+
+    private fun Stats.mdInitRow(label: String): String =
+        "| `$label` | %.1f ms | %.1f | %.1f | %.1f | %.1f |"
+            .format(mean, p50, min, max, stddev)
+
+    private fun writeReport(fileName: String, content: String) {
+        val file = java.io.File(reportDir, fileName)
+        file.parentFile.mkdirs()
+        file.writeText(content)
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // 1. Scan throughput
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun benchmarkScan() {
+        val corpus = buildCorpus()
+
+        println()
+        println("╔══════════════════════════════════════════════════════════════════════╗")
+        println("║              SCAN THROUGHPUT BENCHMARK                              ║")
+        println("╠══════════════════════════════════════════════════════════════════════╣")
+        println("║  Corpus: testText.txt × $CORPUS_REPEAT  ≈ ${corpus.length / 1024} KB")
+        println("║  Matchers: ${kotlinMatchers.size} (Kotlin) / ${hyperMatchers.size} (HyperScan)")
+        println("║  Warmup: $SCAN_WARMUP iters   Measure: $SCAN_MEASURE iters")
+        println("╚══════════════════════════════════════════════════════════════════════╝")
+
+        val kotlinStats: Stats
+        val hyperStats:  Stats
+        var kotlinMatches = 0
+        var hyperMatches  = 0
+
+        KotlinEngine(kotlinMatchers).use { engine ->
+            print("  KotlinEngine    warming up... "); System.out.flush()
+            repeat(SCAN_WARMUP) { engine.scan(corpus) }
+            println("done")
+            val times = LongArray(SCAN_MEASURE)
+            repeat(SCAN_MEASURE) { i -> times[i] = measureNanoTime { kotlinMatches += engine.scan(corpus).size } }
+            kotlinStats = times.stats()
+        }
+
+        HyperScanEngine(hyperMatchers).use { engine ->
+            print("  HyperScanEngine warming up... "); System.out.flush()
+            repeat(SCAN_WARMUP) { engine.scan(corpus) }
+            println("done")
+            val times = LongArray(SCAN_MEASURE)
+            repeat(SCAN_MEASURE) { i -> times[i] = measureNanoTime { hyperMatches += engine.scan(corpus).size } }
+            hyperStats = times.stats()
+        }
+
+        println("  --- results ---")
+        kotlinStats.printScan("KotlinEngine",   corpus.length, kotlinMatches / SCAN_MEASURE)
+        hyperStats.printScan("HyperScanEngine", corpus.length, hyperMatches  / SCAN_MEASURE)
+        println()
+
+        writeReport("benchmark-scan.md", buildString {
+            appendLine("### Scan Throughput")
+            appendLine()
+            appendLine("Corpus: `testText.txt × $CORPUS_REPEAT ≈ ${corpus.length / 1024} KB` | " +
+                       "Matchers: ${kotlinMatchers.size} | " +
+                       "Warmup: $SCAN_WARMUP | Iterations: $SCAN_MEASURE")
+            appendLine()
+            appendLine("| Engine | mean | p50 | σ | Throughput | Matches/iter |")
+            appendLine("|:---|---:|---:|---:|---:|---:|")
+            appendLine(kotlinStats.mdScanRow("KotlinEngine",   corpus.length, kotlinMatches / SCAN_MEASURE))
+            appendLine(hyperStats.mdScanRow("HyperScanEngine", corpus.length, hyperMatches  / SCAN_MEASURE))
+        })
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // 2. Init speed
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun benchmarkInit() {
+        println()
+        println("╔══════════════════════════════════════════════════════════════════════╗")
+        println("║              INIT SPEED BENCHMARK                                   ║")
+        println("╠══════════════════════════════════════════════════════════════════════╣")
+        println("║  Matchers: ${kotlinMatchers.size} (Kotlin) / ${hyperMatchers.size} (HyperScan)")
+        println("║  Warmup: $INIT_WARMUP iters   Measure: $INIT_MEASURE iters")
+        println("╚══════════════════════════════════════════════════════════════════════╝")
+
+        val kotlinStats = measureInit("KotlinEngine   ") { KotlinEngine(kotlinMatchers).also { it.close() } }
+        val hyperStats  = measureInit("HyperScanEngine") { HyperScanEngine(hyperMatchers).also { it.close() } }
+
+        println("  --- results ---")
+        kotlinStats.printInit("KotlinEngine")
+        hyperStats.printInit("HyperScanEngine")
+        println()
+
+        writeReport("benchmark-init.md", buildString {
+            appendLine("### Init Speed")
+            appendLine()
+            appendLine("Matchers: ${kotlinMatchers.size} | Warmup: $INIT_WARMUP | Iterations: $INIT_MEASURE")
+            appendLine()
+            appendLine("| Engine | mean | p50 | min | max | σ |")
+            appendLine("|:---|---:|---:|---:|---:|---:|")
+            appendLine(kotlinStats.mdInitRow("KotlinEngine"))
+            appendLine(hyperStats.mdInitRow("HyperScanEngine"))
+        })
+    }
+
+    private fun measureInit(label: String, factory: () -> Unit): Stats {
+        print("  $label warming up... "); System.out.flush()
+        repeat(INIT_WARMUP) { factory() }
+        println("done")
+        val times = LongArray(INIT_MEASURE)
+        repeat(INIT_MEASURE) { i -> times[i] = measureNanoTime { factory() } }
+        return times.stats()
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // 3. Consistency check
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Prints match counts from both engines on the same text.
+     * A small delta is expected — engines share patterns but differ in edge-case
+     * matching behaviour; known differences are documented in EngineTest.
+     */
+    @Test
+    fun verifyScanConsistency() {
+        val resource = javaClass.getResource("/testFiles/testText.txt")
+        assertNotNull(resource, "testText.txt not found")
+        val text = java.io.File(resource.file).readText()
+
+        val kotlinCount = KotlinEngine(kotlinMatchers).use { it.scan(text).size }
+        val hyperCount  = HyperScanEngine(hyperMatchers).use { it.scan(text).size }
+
+        println("\n  Consistency check on testText.txt:")
+        println("  KotlinEngine    → $kotlinCount matches")
+        println("  HyperScanEngine → $hyperCount matches")
+        val note = if (kotlinCount == hyperCount) "equal"
+                   else "delta=${hyperCount - kotlinCount} (expected — see EngineTest for known differences)"
+        println("  Result: $note")
+
+        writeReport("benchmark-consistency.md", buildString {
+            appendLine("### Match Consistency (`testText.txt`)")
+            appendLine()
+            appendLine("| Engine | Matches |")
+            appendLine("|:---|---:|")
+            appendLine("| `KotlinEngine` | $kotlinCount |")
+            appendLine("| `HyperScanEngine` | $hyperCount |")
+            appendLine()
+            appendLine("_${note}_")
+        })
+    }
+}

--- a/kotlin-lib/src/jvmTest/kotlin/org/angryscan/common/engine/CompiledDatabaseTest.kt
+++ b/kotlin-lib/src/jvmTest/kotlin/org/angryscan/common/engine/CompiledDatabaseTest.kt
@@ -1,0 +1,229 @@
+package org.angryscan.common.engine
+
+import org.angryscan.common.engine.hyperscan.HyperScanEngine
+import org.angryscan.common.engine.hyperscan.IHyperMatcher
+import org.angryscan.common.engine.kotlin.IKotlinMatcher
+import org.angryscan.common.engine.kotlin.KotlinEngine
+import org.angryscan.common.extensions.Matchers
+import org.angryscan.common.matchers.*
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+internal class CompiledDatabaseTest {
+
+    private val hyperMatchers = Matchers.filterIsInstance<IHyperMatcher>()
+    private val kotlinMatchers = Matchers.filterIsInstance<IKotlinMatcher>()
+
+    private fun loadTestText(): String {
+        val resource = javaClass.getResource("/testFiles/testText.txt")
+        assertNotNull(resource, "testText.txt not found")
+        return File(resource.file).readText()
+    }
+
+    private fun loadFirstCsv(): String {
+        val resource = javaClass.getResource("/testFiles/first.csv")
+        assertNotNull(resource, "first.csv not found")
+        return File(resource.file).readText()
+    }
+
+    // ── Functional parity ───────────────────────────────────────────────────
+
+    @Test
+    fun loadFromBytes_matchesColdCompileResults() {
+        val text = loadTestText()
+
+        val compiledBytes: ByteArray
+        val expectedResults: List<Match>
+
+        HyperScanEngine(hyperMatchers).use { engine ->
+            expectedResults = engine.scan(text)
+            compiledBytes = engine.saveCompiledDatabase()
+        }
+
+        HyperScanEngine.fromCompiledDatabase(hyperMatchers, compiledBytes).use { engine ->
+            val loadedResults = engine.scan(text)
+            assertEquals(expectedResults.size, loadedResults.size, "Match count differs between compiled and loaded DB")
+            expectedResults.zip(loadedResults).forEachIndexed { i, (expected, loaded) ->
+                assertEquals(expected.value, loaded.value, "Match value differs at index $i")
+                assertEquals(expected.startPosition, loaded.startPosition, "Start position differs at index $i")
+                assertEquals(expected.endPosition, loaded.endPosition, "End position differs at index $i")
+                assertEquals(expected.matcher.name, loaded.matcher.name, "Matcher name differs at index $i")
+            }
+        }
+    }
+
+    @Test
+    fun loadFromFile_matchesColdCompileResults() {
+        val text = loadFirstCsv()
+        val tmpFile = File.createTempFile("hyperscan-db-", ".bin")
+
+        try {
+            val expectedResults: List<Match>
+
+            HyperScanEngine(hyperMatchers).use { engine ->
+                expectedResults = engine.scan(text)
+                engine.saveCompiledDatabase(tmpFile)
+            }
+
+            assertTrue(tmpFile.length() > 0, "Compiled database file should not be empty")
+
+            HyperScanEngine.fromCompiledDatabase(hyperMatchers, tmpFile).use { engine ->
+                val loadedResults = engine.scan(text)
+                assertEquals(expectedResults.size, loadedResults.size, "Match count differs between compiled and loaded DB from file")
+                expectedResults.zip(loadedResults).forEachIndexed { i, (expected, loaded) ->
+                    assertEquals(expected.value, loaded.value, "Match value differs at index $i")
+                    assertEquals(expected.startPosition, loaded.startPosition, "Start position differs at index $i")
+                    assertEquals(expected.endPosition, loaded.endPosition, "End position differs at index $i")
+                    assertEquals(expected.matcher.name, loaded.matcher.name, "Matcher name differs at index $i")
+                }
+            }
+        } finally {
+            tmpFile.delete()
+        }
+    }
+
+    @Test
+    fun loadedDb_matchesKotlinEngineByCount() {
+        val text = loadTestText()
+
+        val compiledBytes: ByteArray
+        HyperScanEngine(hyperMatchers).use { engine ->
+            compiledBytes = engine.saveCompiledDatabase()
+        }
+
+        val kotlinCount = KotlinEngine(kotlinMatchers).use { it.scan(text).size }
+        val loadedHyperCount = HyperScanEngine.fromCompiledDatabase(hyperMatchers, compiledBytes).use {
+            it.scan(text).size
+        }
+
+        assertEquals(
+            kotlinCount, loadedHyperCount,
+            "Loaded HyperScanEngine match count ($loadedHyperCount) should equal KotlinEngine count ($kotlinCount)"
+        )
+    }
+
+    // ── Context correctness ─────────────────────────────────────────────────
+
+    @Test
+    fun loadedDb_contextIsCorrect() {
+        val text = loadFirstCsv()
+        val singleMatcher = listOf(CardNumber() as IHyperMatcher)
+
+        val compiledBytes: ByteArray
+        HyperScanEngine(singleMatcher).use { engine ->
+            compiledBytes = engine.saveCompiledDatabase()
+        }
+
+        HyperScanEngine.fromCompiledDatabase(singleMatcher, compiledBytes).use { engine ->
+            val results = engine.scan(text)
+            assertEquals(1, results.size, "Expected 1 CardNumber match")
+            assertTrue(results.first().value.contains("4276 8070 1492 7948"))
+            assertTrue(results.first().before.contains("Карта"))
+            assertTrue(results.first().after.contains("г. Санкт"))
+        }
+    }
+
+    // ── Strict-fail validation ──────────────────────────────────────────────
+
+    @Test
+    fun loadFailsOnMatcherSetMismatch() {
+        val fullMatchers = hyperMatchers
+        val subsetMatchers = listOf(Email as IHyperMatcher, Phone as IHyperMatcher)
+
+        val compiledBytes: ByteArray
+        HyperScanEngine(fullMatchers).use { engine ->
+            compiledBytes = engine.saveCompiledDatabase()
+        }
+
+        assertFailsWith<IllegalArgumentException>(
+            "Should fail when loading with a different matcher set"
+        ) {
+            HyperScanEngine.fromCompiledDatabase(subsetMatchers, compiledBytes)
+        }
+    }
+
+    @Test
+    fun loadFailsOnRequireKeywordsMismatch() {
+        val compiledBytes: ByteArray
+        HyperScanEngine(hyperMatchers, requireKeywords = true).use { engine ->
+            compiledBytes = engine.saveCompiledDatabase()
+        }
+
+        assertFailsWith<IllegalArgumentException>(
+            "Should fail when requireKeywords differs"
+        ) {
+            HyperScanEngine.fromCompiledDatabase(hyperMatchers, compiledBytes, requireKeywords = false)
+        }
+    }
+
+    // ── Corrupted data ──────────────────────────────────────────────────────
+
+    @Test
+    fun loadFailsOnCorruptedManifest() {
+        assertFailsWith<IllegalArgumentException>(
+            "Should fail on random bytes"
+        ) {
+            HyperScanEngine.fromCompiledDatabase(hyperMatchers, ByteArray(64) { 0xFF.toByte() })
+        }
+    }
+
+    @Test
+    fun loadFailsOnEmptyBytes() {
+        assertFailsWith<Exception>(
+            "Should fail on empty bytes"
+        ) {
+            HyperScanEngine.fromCompiledDatabase(hyperMatchers, ByteArray(0))
+        }
+    }
+
+    @Test
+    fun loadFailsOnTruncatedManifest() {
+        val compiledBytes: ByteArray
+        HyperScanEngine(hyperMatchers).use { engine ->
+            compiledBytes = engine.saveCompiledDatabase()
+        }
+
+        assertFailsWith<Exception>(
+            "Should fail on truncated data"
+        ) {
+            HyperScanEngine.fromCompiledDatabase(hyperMatchers, compiledBytes.copyOf(10))
+        }
+    }
+
+    // ── Resource lifecycle ──────────────────────────────────────────────────
+
+    @Test
+    fun loadedEngine_closeDoesNotThrow() {
+        val compiledBytes: ByteArray
+        HyperScanEngine(hyperMatchers).use { engine ->
+            compiledBytes = engine.saveCompiledDatabase()
+        }
+
+        val engine = HyperScanEngine.fromCompiledDatabase(hyperMatchers, compiledBytes)
+        engine.close()
+    }
+
+    @Test
+    fun saveAndLoadMultipleTimes_consistent() {
+        val text = loadTestText()
+
+        val bytes1: ByteArray
+        HyperScanEngine(hyperMatchers).use { engine ->
+            bytes1 = engine.saveCompiledDatabase()
+        }
+
+        val bytes2: ByteArray
+        HyperScanEngine.fromCompiledDatabase(hyperMatchers, bytes1).use { engine ->
+            bytes2 = engine.saveCompiledDatabase()
+        }
+
+        HyperScanEngine.fromCompiledDatabase(hyperMatchers, bytes2).use { engine ->
+            val results = engine.scan(text)
+            assertTrue(results.isNotEmpty(), "Should find matches after double save/load cycle")
+        }
+    }
+}

--- a/kotlin-lib/src/nativeMain/kotlin/org/angryscan/common/constants/CardBins.kt
+++ b/kotlin-lib/src/nativeMain/kotlin/org/angryscan/common/constants/CardBins.kt
@@ -1,8 +1,7 @@
 package org.angryscan.common.constants
 
 actual object CardBins {
-    actual val cardBins: List<String>
-        get() = listOf(
+    actual val cardBins: Set<String> = setOf(
             "3528",
             "3530",
             "3531",


### PR DESCRIPTION
- KotlinEngine: pre-compile regex patterns once at init instead of per scan (~46% faster)
- Matchers: move per-call regex/list constructions to object-level constants
- CardBins: List -> Set for O(1) BIN lookup
- HyperScanEngine: drop unnecessary toMutableList() conversion
- Add BenchmarkTest covering scan throughput, init speed and match consistency
- CI: post benchmark results as PR comment via actions/github-script